### PR TITLE
Fetch FE Accounts fresh for user, only cache as needed

### DIFF
--- a/app/(private)/batchManagement/page.tsx
+++ b/app/(private)/batchManagement/page.tsx
@@ -1,22 +1,20 @@
-
-import { redirect } from 'next/navigation'
+import { BatchPreview } from '@/components/dashboard/batch-preview'
 import { MappingCreateButton } from '@/components/dashboard/mapping-create-button'
-
-import { Stepper } from '@/components/stepper'
-import { getVirtuousProjects } from '@/lib/virProjects'
-import { getFeAccounts } from '@/lib/feAccounts'
-import { getProjectAccountMappings } from '@/lib/virProjects'
-import { getVirtuousBatches} from '@/lib/virGifts'
 import { VirtuousSyncButton } from '@/components/dashboard/virtuous-sync-button'
 import { EmptyPlaceholder } from '@/components/empty-placeholder'
-import { BatchPreview } from '@/components/dashboard/batch-preview'
-import { db } from '@/lib/db'
 import { MainNav } from '@/components/main-nav'
 import { DashboardNav } from '@/components/nav'
 import { SiteFooter } from '@/components/site-footer'
+import { Stepper } from '@/components/stepper'
 import { UserAccountNav } from '@/components/user-account-nav'
 import { dashboardConfig } from '@/config/dashboard'
+import { db } from '@/lib/db'
+import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
 import { getCurrentUser } from '@/lib/session'
+import { getVirtuousBatches } from '@/lib/virGifts'
+import { getVirtuousProjects } from '@/lib/virProjects'
+import { getProjectAccountMappings } from '@/lib/virProjects'
+import { redirect } from 'next/navigation'
 import { notFound } from 'next/navigation'
 
 const getFeEnvironment = async (user) => {
@@ -24,58 +22,68 @@ const getFeEnvironment = async (user) => {
     select: {
       id: true,
       environment_id: true,
-     
-    }, 
+    },
     where: {
       teamId: user.team.id,
-    }
+    },
   })
 }
 
-  export const metadata = {
-    title: 'Review your data',
-    description: 'Double Check Your Mapping Before Syncing.',
-  }
+export const metadata = {
+  title: 'Review your data',
+  description: 'Double Check Your Mapping Before Syncing.',
+}
 
 // get FE journal name based on user's default journal
 const getFeJournalName = async (journalId, teamId) => {
   return await db.feJournal.findFirst({
     select: {
       journal: true,
-      id: true, 
+      id: true,
     },
     where: {
-        teamId: teamId,
-        id: parseInt(journalId),
+      teamId: teamId,
+      id: parseInt(journalId),
     },
   })
 }
 
-  // Get Batches from Latest Gifts for Samples
-
-
+// Get Batches from Latest Gifts for Samples
 
 export default async function ReveiwDataPage() {
-    const user = await getCurrentUser()
-    if (!user) { redirect('/login') }
+  const user = await getCurrentUser()
+  if (!user) {
+    redirect('/login')
+  }
 
-   
-    const feAccountsData = getFeAccounts(user)
-    const projectsData = getVirtuousProjects(user)
-    const mappingData = getProjectAccountMappings(user)
-    const batchData = getVirtuousBatches(user)
-    const feEnvironmentData = getFeEnvironment(user)
-    const feGetJournalName = getFeJournalName(user?.team.defaultJournal, user.team.id)
-    const [projects, feAccounts, mappings, batches, feEnvironment, journalName] = await Promise.all([projectsData, feAccountsData, mappingData, batchData, feEnvironmentData, feGetJournalName  ])
-    
-    if (!feEnvironment) { 
-      redirect('/step2')
-    }
-    if (!journalName) { 
-      redirect('/step3')
-    }
-  return (<>
-  <header className="sticky top-0 z-40 border-b bg-background">
+  const feAccountsData = getFeAccountsFromBlackbaud(user)
+  const projectsData = getVirtuousProjects(user)
+  const mappingData = getProjectAccountMappings(user)
+  const batchData = getVirtuousBatches(user)
+  const feEnvironmentData = getFeEnvironment(user)
+  const feGetJournalName = getFeJournalName(
+    user?.team.defaultJournal,
+    user.team.id
+  )
+  const [projects, feAccounts, mappings, batches, feEnvironment, journalName] =
+    await Promise.all([
+      projectsData,
+      feAccountsData,
+      mappingData,
+      batchData,
+      feEnvironmentData,
+      feGetJournalName,
+    ])
+
+  if (!feEnvironment) {
+    redirect('/step2')
+  }
+  if (!journalName) {
+    redirect('/step3')
+  }
+  return (
+    <>
+      <header className="sticky top-0 z-40 border-b bg-background">
         <div className="container flex h-16 items-center justify-between py-4">
           <MainNav items={dashboardConfig.mainNav} />
           <UserAccountNav
@@ -87,24 +95,24 @@ export default async function ReveiwDataPage() {
           />
         </div>
       </header>
-    <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
-    {batches && feAccounts && mappings && projects ? (
-           <BatchPreview
-           batches={batches}
-           projects={projects}
-           feAccounts={feAccounts}
-           mappings={mappings}
-           defaultCreditAccount={user?.team.defaultCreditAccount}
-           defaultDebitAccount={user?.team.defaultDebitAccount}
-           defaultJournal={user?.team.defaultJournal} 
-           feEnvironment={feEnvironment.environment_id}
-           journalName={journalName.journal}
-           className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
-         />
-        ) : `getting projects and accounts...`}
-      
-     
-    </div>
+      <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
+        {batches && feAccounts && mappings && projects ? (
+          <BatchPreview
+            batches={batches}
+            projects={projects}
+            feAccounts={feAccounts}
+            mappings={mappings}
+            defaultCreditAccount={user?.team.defaultCreditAccount}
+            defaultDebitAccount={user?.team.defaultDebitAccount}
+            defaultJournal={user?.team.defaultJournal}
+            feEnvironment={feEnvironment.environment_id}
+            journalName={journalName.journal}
+            className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          />
+        ) : (
+          `getting projects and accounts...`
+        )}
+      </div>
     </>
   )
 }

--- a/app/(private)/dashboard/settings/page.tsx
+++ b/app/(private)/dashboard/settings/page.tsx
@@ -15,6 +15,7 @@ import {
 import { UserNameForm } from '@/components/user-name-form'
 import { authOptions } from '@/lib/auth'
 import { db } from '@/lib/db'
+import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
 import { getCurrentUser } from '@/lib/session'
 import { User } from '@prisma/client'
 import { redirect } from 'next/navigation'
@@ -81,6 +82,7 @@ export default async function SettingsPage() {
   }
   const apiKey = await getApiKey(user.team.id)
   const data = await reSettingsForUser(user.team.id)
+  const feAccounts = await getFeAccountsFromBlackbaud(user)
   return (
     <DashboardShell>
       <DashboardHeader
@@ -164,6 +166,7 @@ export default async function SettingsPage() {
                   ]}
                   selected={user?.defaultDebitAccount}
                   redirect="/dashboard/settings"
+                  initialData={feAccounts}
                 />
               </div>
             </div>
@@ -184,6 +187,7 @@ export default async function SettingsPage() {
                   subType="credit"
                   selected={user?.defaultCreditAccount}
                   redirect="/dashboard/settings"
+                  initialData={feAccounts}
                 />
               </div>
             </div>

--- a/app/(private)/projectMapping/page.tsx
+++ b/app/(private)/projectMapping/page.tsx
@@ -1,22 +1,80 @@
-
-import { db } from '@/lib/db'
-import { getCurrentUser } from '@/lib/session'
-
 import { MappingCreateButton } from '@/components/dashboard/mapping-create-button'
-
-import { upsertFeAccount } from '@/lib/feAccounts'
+import { db } from '@/lib/db'
+import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
 import { reFetch } from '@/lib/reFetch'
-import { upsertProject } from '@/lib/virProjects'
+import { getCurrentUser } from '@/lib/session'
 import { virApiFetch } from '@/lib/virApiFetch'
+import { upsertProject } from '@/lib/virProjects'
 
+export const metadata = {
+  title: 'Map your data',
+  description: 'Select which projects should map to which accounts.',
+}
 
-  export const metadata = {
-    title: 'Map your data',
-    description: 'Select which projects should map to which accounts.',
-  }
-  
-  const getVirtuousProjects = async (user) => {
-    let projects = await db.virtuousProject.findMany({
+const getVirtuousProjects = async (user) => {
+  let projects = await db.virtuousProject.findMany({
+    select: {
+      id: true,
+      name: true,
+      project_id: true,
+      projectCode: true,
+      onlineDisplayName: true,
+      externalAccountingCode: true,
+      description: true,
+      isActive: true,
+      isPublic: true,
+      isTaxDeductible: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: {
+      teamId: user.team.id,
+    },
+    orderBy: {
+      onlineDisplayName: 'asc',
+    },
+  })
+
+  if (projects.length < 1) {
+    console.log('no initial projects...querying virtuous')
+    const body = {
+      groups: [
+        {
+          conditions: [
+            {
+              parameter: 'Create Date',
+              operator: 'LessThanOrEqual',
+              value: '30 Days Ago',
+            },
+            {
+              parameter: 'Active',
+              operator: 'IsTrue',
+            },
+          ],
+        },
+      ],
+      sortBy: 'Last Modified Date',
+      descending: 'true',
+    }
+    const res = await virApiFetch(
+      'https://api.virtuoussoftware.com/api/Project/Query?skip=0&take=1000',
+      'POST',
+      user.team.id,
+      body
+    )
+
+    console.log('after virApiFetch')
+    console.log(res.status)
+    if (res.status !== 200) {
+      console.log('no projects')
+    }
+    console.log('returning data')
+    const data = await res.json()
+    console.log(data)
+    data?.list.forEach((project) => {
+      upsertProject(project, user.id)
+    })
+    return await db.virtuousProject.findMany({
       select: {
         id: true,
         name: true,
@@ -26,7 +84,7 @@ import { virApiFetch } from '@/lib/virApiFetch'
         externalAccountingCode: true,
         description: true,
         isActive: true,
-        isPublic: true, 
+        isPublic: true,
         isTaxDeductible: true,
         createdAt: true,
         updatedAt: true,
@@ -38,190 +96,53 @@ import { virApiFetch } from '@/lib/virApiFetch'
         onlineDisplayName: 'asc',
       },
     })
-
-      if (projects.length < 1) {
-        console.log('no initial projects...querying virtuous')
-      const body = {
-        groups: [
-          {
-            conditions: [
-              {
-                parameter: 'Create Date',
-                operator: 'LessThanOrEqual',
-                value: '30 Days Ago',
-              },
-              {
-                parameter: 'Active',
-                operator: 'IsTrue',
-              },
-            ],
-          },
-        ],
-        sortBy: 'Last Modified Date',
-        descending: 'true',
-      }
-      const res = await virApiFetch('https://api.virtuoussoftware.com/api/Project/Query?skip=0&take=1000', 'POST', user.team.id, body)
-
-      console.log('after virApiFetch')
-      console.log(res.status)
-      if (res.status !== 200) {
-        console.log('no projects')
-
-      }
-      console.log('returning data')
-      const data = await res.json()
-      console.log(data)
-      data?.list.forEach((project) => {
-        upsertProject(project, user.id)
-      })
-      return await db.virtuousProject.findMany({
-        select: {
-          id: true,
-          name: true,
-          project_id: true,
-          projectCode: true,
-          onlineDisplayName: true,
-          externalAccountingCode: true,
-          description: true,
-          isActive: true,
-          isPublic: true, 
-          isTaxDeductible: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-        where: {
-          teamId: user.team.id,
-        },
-        orderBy: {
-          onlineDisplayName: 'asc',
-        },
-      })
-
-    }
-   return projects 
   }
+  return projects
+}
 
-  const getFeProjects = async (user) => {
-    return await db.feProject.findMany({
-      select: {
-        id: true,
-        project_id: true,
-        ui_project_id: true,
-        description: true,
-        location: true,
-        division: true,
-        department: true,
-        status: true,
-        createdAt: true,
-        updatedAt: true,
-      }, 
-      where: {
-        teamId: user.team.id,
-      },
-      orderBy: {
-        description: 'asc',
-      },
-    })
-  }
-
-  const getProjectAccountMappings = async (user) => {
-    return await db.projectAccountMapping.findMany({
-      select: {
-        id: true,
-        virProjectId: true,
-        feAccountId: true,
-        
-      }, 
-      where: {
-        teamId: user.team.id,
-      },
-    })
-  }
-
-
-  const getFeAccounts = async (user) => {
-    let accounts =  await db.feAccount.findMany({
-      select: {
-        account_id: true,
-        account_number: true,       
-        description: true,          
-        class: true,
-        cashflow: true,
-        working_capital: true,
-        default_transaction_codes: true, 
-    
-      },
-      where: {
-        teamId: user.team.id,
-      },
-      orderBy: {
-        description: 'asc',
-      },
-    })
-
-    if (accounts && accounts.length < 1) {
-      console.log('call blackbaud api')
-      const res2 = await reFetch('https://api.sky.blackbaud.com/generalledger/v1/accounts','GET', user.id)
-      if (res2.status !== 200) {
-        console.log('no accounts found')
-
-      } else { 
-        console.log('got accounts')
-        const data = await res2.json()
-        data?.value.forEach((account) => {
-          upsertFeAccount(account, user.team.id)
-        })
-      }
-     return accounts =  await db.feAccount.findMany({
-        select: {
-          account_id: true,
-          account_number: true,       
-          description: true,          
-          class: true,
-          cashflow: true,
-          working_capital: true,
-          default_transaction_codes: true, 
-        },
-        where: {
-          teamId: user.team.id,
-        },
-        orderBy: {
-          description: 'asc',
-        },
-      })
-    }
-    return accounts 
-  }
-
-
-
-
+const getProjectAccountMappings = async (user) => {
+  return await db.projectAccountMapping.findMany({
+    select: {
+      id: true,
+      virProjectId: true,
+      feAccountId: true,
+    },
+    where: {
+      teamId: user.team.id,
+    },
+  })
+}
 
 export default async function DataMapPage() {
-    const user = await getCurrentUser()
-    if (!user) { return null}
-    const feAccountsData= getFeAccounts(user)
-    const projectsData= getVirtuousProjects(user)
-    const mappingData= getProjectAccountMappings(user)
-    const [projects, feAccounts, mappings] = await Promise.all([projectsData, feAccountsData, mappingData])
-    console.log('accounts length: ', feAccounts.length)
-    console.log('projects length: ', projects.length)
-    
+  const user = await getCurrentUser()
+  if (!user) {
+    return null
+  }
+  const feAccountsData = getFeAccountsFromBlackbaud(user)
+  const projectsData = getVirtuousProjects(user)
+  const mappingData = getProjectAccountMappings(user)
+  const [projects, feAccounts, mappings] = await Promise.all([
+    projectsData,
+    feAccountsData,
+    mappingData,
+  ])
+  console.log('accounts length: ', feAccounts.length)
+  console.log('projects length: ', projects.length)
 
-
-  return (<>
-    <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
-    {projects && feAccounts ? (
+  return (
+    <>
+      <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
+        {projects && feAccounts ? (
           <MappingCreateButton
             projects={projects}
             feAccounts={feAccounts}
             mappings={mappings}
             className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
           />
-        ) : `getting projects and accounts...`}
-      
-     
-    </div>
+        ) : (
+          `getting projects and accounts...`
+        )}
+      </div>
     </>
   )
 }

--- a/app/(signupWizard)/step5/page.tsx
+++ b/app/(signupWizard)/step5/page.tsx
@@ -1,22 +1,79 @@
-
-import { db } from '@/lib/db'
-import { getCurrentUser } from '@/lib/session'
-
 import { MappingCreateButton } from '@/components/dashboard/mapping-create-button'
-
-import { upsertFeAccount } from '@/lib/feAccounts'
-import { reFetch } from '@/lib/reFetch'
-import { upsertProject } from '@/lib/virProjects'
+import { db } from '@/lib/db'
+import { getFeAccountsFromBlackbaud, upsertFeAccount } from '@/lib/feAccounts'
+import { getCurrentUser } from '@/lib/session'
 import { virApiFetch } from '@/lib/virApiFetch'
+import { upsertProject } from '@/lib/virProjects'
 
+export const metadata = {
+  title: 'Map your data',
+  description: 'Select which projects should map to which accounts.',
+}
 
-  export const metadata = {
-    title: 'Map your data',
-    description: 'Select which projects should map to which accounts.',
-  }
-  
-  const getVirtuousProjects = async (user) => {
-    let projects = await db.virtuousProject.findMany({
+const getVirtuousProjects = async (user) => {
+  let projects = await db.virtuousProject.findMany({
+    select: {
+      id: true,
+      name: true,
+      project_id: true,
+      projectCode: true,
+      onlineDisplayName: true,
+      externalAccountingCode: true,
+      description: true,
+      isActive: true,
+      isPublic: true,
+      isTaxDeductible: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: {
+      teamId: user.team.id,
+    },
+    orderBy: {
+      onlineDisplayName: 'asc',
+    },
+  })
+
+  if (projects.length < 1) {
+    console.log('no initial projects...querying virtuous')
+    const body = {
+      groups: [
+        {
+          conditions: [
+            {
+              parameter: 'Create Date',
+              operator: 'LessThanOrEqual',
+              value: '30 Days Ago',
+            },
+            {
+              parameter: 'Active',
+              operator: 'IsTrue',
+            },
+          ],
+        },
+      ],
+      sortBy: 'Last Modified Date',
+      descending: 'true',
+    }
+    const res = await virApiFetch(
+      'https://api.virtuoussoftware.com/api/Project/Query?skip=0&take=1000',
+      'POST',
+      user.team.id,
+      body
+    )
+
+    console.log('after virApiFetch')
+    console.log(res.status)
+    if (res.status !== 200) {
+      console.log('no projects')
+    }
+    console.log('returning data')
+    const data = await res.json()
+    console.log(data)
+    data?.list.forEach((project) => {
+      upsertProject(project, user.team.id)
+    })
+    return await db.virtuousProject.findMany({
       select: {
         id: true,
         name: true,
@@ -26,7 +83,7 @@ import { virApiFetch } from '@/lib/virApiFetch'
         externalAccountingCode: true,
         description: true,
         isActive: true,
-        isPublic: true, 
+        isPublic: true,
         isTaxDeductible: true,
         createdAt: true,
         updatedAt: true,
@@ -38,190 +95,76 @@ import { virApiFetch } from '@/lib/virApiFetch'
         onlineDisplayName: 'asc',
       },
     })
-
-      if (projects.length < 1) {
-        console.log('no initial projects...querying virtuous')
-      const body = {
-        groups: [
-          {
-            conditions: [
-              {
-                parameter: 'Create Date',
-                operator: 'LessThanOrEqual',
-                value: '30 Days Ago',
-              },
-              {
-                parameter: 'Active',
-                operator: 'IsTrue',
-              },
-            ],
-          },
-        ],
-        sortBy: 'Last Modified Date',
-        descending: 'true',
-      }
-      const res = await virApiFetch('https://api.virtuoussoftware.com/api/Project/Query?skip=0&take=1000', 'POST', user.team.id, body)
-
-      console.log('after virApiFetch')
-      console.log(res.status)
-      if (res.status !== 200) {
-        console.log('no projects')
-
-      }
-      console.log('returning data')
-      const data = await res.json()
-      console.log(data)
-      data?.list.forEach((project) => {
-        upsertProject(project, user.team.id)
-      })
-      return await db.virtuousProject.findMany({
-        select: {
-          id: true,
-          name: true,
-          project_id: true,
-          projectCode: true,
-          onlineDisplayName: true,
-          externalAccountingCode: true,
-          description: true,
-          isActive: true,
-          isPublic: true, 
-          isTaxDeductible: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-        where: {
-          teamId: user.team.id,
-        },
-        orderBy: {
-          onlineDisplayName: 'asc',
-        },
-      })
-
-    }
-   return projects 
   }
+  return projects
+}
 
-  const getFeProjects = async (user) => {
-    return await db.feProject.findMany({
-      select: {
-        id: true,
-        project_id: true,
-        ui_project_id: true,
-        description: true,
-        location: true,
-        division: true,
-        department: true,
-        status: true,
-        createdAt: true,
-        updatedAt: true,
-      }, 
-      where: {
-        teamId: user.team.id,
-      },
-      orderBy: {
-        description: 'asc',
-      },
-    })
-  }
+const getFeProjects = async (user) => {
+  return await db.feProject.findMany({
+    select: {
+      id: true,
+      project_id: true,
+      ui_project_id: true,
+      description: true,
+      location: true,
+      division: true,
+      department: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: {
+      teamId: user.team.id,
+    },
+    orderBy: {
+      description: 'asc',
+    },
+  })
+}
 
-  const getProjectAccountMappings = async (user) => {
-    return await db.projectAccountMapping.findMany({
-      select: {
-        id: true,
-        virProjectId: true,
-        feAccountId: true,
-        
-      }, 
-      where: {
-        teamId: user.team.id,
-      },
-    })
-  }
-
-
-  const getFeAccounts = async (user) => {
-    let accounts =  await db.feAccount.findMany({
-      select: {
-        account_id: true,
-        account_number: true,       
-        description: true,          
-        class: true,
-        cashflow: true,
-        working_capital: true,
-        default_transaction_codes: true, 
-    
-      },
-      where: {
-        teamId: user.team.id,
-      },
-      orderBy: {
-        description: 'asc',
-      },
-    })
-
-    if (accounts && accounts.length < 1) {
-      console.log('call blackbaud api')
-      const res2 = await reFetch('https://api.sky.blackbaud.com/generalledger/v1/accounts','GET', user.team.id)
-      if (res2.status !== 200) {
-        console.log('no accounts found')
-
-      } else { 
-        console.log('got accounts')
-        const data = await res2.json()
-        data?.value.forEach((account) => {
-          upsertFeAccount(account, user.team.id)
-        })
-      }
-     return accounts =  await db.feAccount.findMany({
-        select: {
-          account_id: true,
-          account_number: true,       
-          description: true,          
-          class: true,
-          cashflow: true,
-          working_capital: true,
-          default_transaction_codes: true, 
-        },
-        where: {
-          teamId: user.team.id,
-        },
-        orderBy: {
-          description: 'asc',
-        },
-      })
-    }
-    return accounts 
-  }
-
-
-
-
+const getProjectAccountMappings = async (user) => {
+  return await db.projectAccountMapping.findMany({
+    select: {
+      id: true,
+      virProjectId: true,
+      feAccountId: true,
+    },
+    where: {
+      teamId: user.team.id,
+    },
+  })
+}
 
 export default async function DataMapPage() {
-    const user = await getCurrentUser()
-    if (!user) { return null}
-    const feAccountsData= getFeAccounts(user)
-    const projectsData= getVirtuousProjects(user)
-    const mappingData= getProjectAccountMappings(user)
-    const [projects, feAccounts, mappings] = await Promise.all([projectsData, feAccountsData, mappingData])
-    console.log('accounts length: ', feAccounts.length)
-    console.log('projects length: ', projects.length)
-    
+  const user = await getCurrentUser()
+  if (!user) {
+    return null
+  }
+  const feAccountsData = getFeAccountsFromBlackbaud(user)
+  const projectsData = getVirtuousProjects(user)
+  const mappingData = getProjectAccountMappings(user)
+  const [projects, feAccounts, mappings] = await Promise.all([
+    projectsData,
+    feAccountsData,
+    mappingData,
+  ])
+  console.log('accounts length: ', feAccounts.length)
+  console.log('projects length: ', projects.length)
 
-
-  return (<>
-    <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
-    {projects && feAccounts ? (
+  return (
+    <>
+      <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
+        {projects && feAccounts ? (
           <MappingCreateButton
             projects={projects}
             feAccounts={feAccounts}
             mappings={mappings}
             className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
           />
-        ) : `getting projects and accounts...`}
-      
-     
-    </div>
+        ) : (
+          `getting projects and accounts...`
+        )}
+      </div>
     </>
   )
 }

--- a/app/(signupWizard)/step6/page.tsx
+++ b/app/(signupWizard)/step6/page.tsx
@@ -1,92 +1,100 @@
-
-import { getCurrentUser } from '@/lib/session'
-import { redirect } from 'next/navigation'
+import { BatchPreview } from '@/components/dashboard/batch-preview'
 import { MappingCreateButton } from '@/components/dashboard/mapping-create-button'
-
-import { Stepper } from '@/components/stepper'
-import { getVirtuousProjects } from '@/lib/virProjects'
-import { getFeAccounts } from '@/lib/feAccounts'
-import { getProjectAccountMappings } from '@/lib/virProjects'
-import { getVirtuousBatches} from '@/lib/virGifts'
 import { VirtuousSyncButton } from '@/components/dashboard/virtuous-sync-button'
 import { EmptyPlaceholder } from '@/components/empty-placeholder'
-import { BatchPreview } from '@/components/dashboard/batch-preview'
+import { Stepper } from '@/components/stepper'
 import { db } from '@/lib/db'
+import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
+import { getCurrentUser } from '@/lib/session'
+import { getVirtuousBatches } from '@/lib/virGifts'
+import { getVirtuousProjects } from '@/lib/virProjects'
+import { getProjectAccountMappings } from '@/lib/virProjects'
+import { redirect } from 'next/navigation'
 
 const getFeEnvironment = async (user) => {
   return await db.feSetting.findFirst({
     select: {
       id: true,
       environment_id: true,
-     
-    }, 
+    },
     where: {
       teamId: user.team.id,
-    }
+    },
   })
 }
 
-  export const metadata = {
-    title: 'Review your data',
-    description: 'Double Check Your Mapping Before Syncing.',
-  }
+export const metadata = {
+  title: 'Review your data',
+  description: 'Double Check Your Mapping Before Syncing.',
+}
 
 // get FE journal name based on user's default journal
 const getFeJournalName = async (journalId, teamId) => {
   return await db.feJournal.findFirst({
     select: {
       journal: true,
-      id: true, 
+      id: true,
     },
     where: {
-        teamId: teamId,
-        id: parseInt(journalId),
+      teamId: teamId,
+      id: parseInt(journalId),
     },
   })
 }
 
-  // Get Batches from Latest Gifts for Samples
-
-
+// Get Batches from Latest Gifts for Samples
 
 export default async function ReveiwDataPage() {
-    const user = await getCurrentUser()
-    if (!user) { redirect('/login') }
+  const user = await getCurrentUser()
+  if (!user) {
+    redirect('/login')
+  }
 
-   
-    const feAccountsData = getFeAccounts(user)
-    const projectsData = getVirtuousProjects(user)
-    const mappingData = getProjectAccountMappings(user)
-    const batchData = getVirtuousBatches(user)
-    const feEnvironmentData = getFeEnvironment(user)
-    const feGetJournalName = getFeJournalName(user?.team?.defaultJournal, user.team.id)
-    const [projects, feAccounts, mappings, batches, feEnvironment, journalName] = await Promise.all([projectsData, feAccountsData, mappingData, batchData, feEnvironmentData, feGetJournalName  ])
-    
-    if (!feEnvironment) { 
-      redirect('/step2')
-    }
-    if (!journalName) { 
-      redirect('/step3')
-    }
-  return (<>
-    <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
-    {batches && feAccounts && mappings && projects ? (
-           <BatchPreview
-           batches={batches}
-           projects={projects}
-           feAccounts={feAccounts}
-           mappings={mappings}
-           defaultCreditAccount={user?.team.defaultCreditAccount}
-           defaultDebitAccount={user?.team.defaultDebitAccount}
-           defaultJournal={user?.team.defaultJournal} 
-           feEnvironment={feEnvironment.environment_id}
-           journalName={journalName.journal}
-           className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
-         />
-        ) : `getting projects and accounts...`}
-      
-     
-    </div>
+  const feAccountsData = getFeAccountsFromBlackbaud(user)
+  const projectsData = getVirtuousProjects(user)
+  const mappingData = getProjectAccountMappings(user)
+  const batchData = getVirtuousBatches(user)
+  const feEnvironmentData = getFeEnvironment(user)
+  const feGetJournalName = getFeJournalName(
+    user?.team?.defaultJournal,
+    user.team.id
+  )
+  const [projects, feAccounts, mappings, batches, feEnvironment, journalName] =
+    await Promise.all([
+      projectsData,
+      feAccountsData,
+      mappingData,
+      batchData,
+      feEnvironmentData,
+      feGetJournalName,
+    ])
+
+  if (!feEnvironment) {
+    redirect('/step2')
+  }
+  if (!journalName) {
+    redirect('/step3')
+  }
+  return (
+    <>
+      <div className="container grid w-screen  grid-cols-3  flex-col items-center bg-dark  lg:max-w-none lg:grid-cols-3 lg:px-0">
+        {batches && feAccounts && mappings && projects ? (
+          <BatchPreview
+            batches={batches}
+            projects={projects}
+            feAccounts={feAccounts}
+            mappings={mappings}
+            defaultCreditAccount={user?.team.defaultCreditAccount}
+            defaultDebitAccount={user?.team.defaultDebitAccount}
+            defaultJournal={user?.team.defaultJournal}
+            feEnvironment={feEnvironment.environment_id}
+            journalName={journalName.journal}
+            className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          />
+        ) : (
+          `getting projects and accounts...`
+        )}
+      </div>
     </>
   )
 }

--- a/app/(signupWizard)/step7/page.tsx
+++ b/app/(signupWizard)/step7/page.tsx
@@ -1,89 +1,93 @@
-
-import { getCurrentUser } from '@/lib/session'
-
-import { getVirtuousProjects } from '@/lib/virProjects'
-import { getFeAccounts } from '@/lib/feAccounts'
-import { getProjectAccountMappings } from '@/lib/virProjects'
-import { getVirtuousBatches} from '@/lib/virGifts'
-
-import { FeFrame} from '@/components/dashboard/fe-frame'
+import { FeFrame } from '@/components/dashboard/fe-frame'
 import { db } from '@/lib/db'
+import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
+import { getCurrentUser } from '@/lib/session'
+import { getVirtuousBatches } from '@/lib/virGifts'
+import { getVirtuousProjects } from '@/lib/virProjects'
+import { getProjectAccountMappings } from '@/lib/virProjects'
 import { redirect } from 'next/navigation'
+
 const getFeEnvironment = async (user) => {
   return await db.feSetting.findFirst({
     select: {
       id: true,
       environment_id: true,
-     
-    }, 
+    },
     where: {
       teamId: user.team.id,
-    }
+    },
   })
 }
 
-  export const metadata = {
-    title: 'Sync First Batch',
-    description: 'See how your sync turned out.',
-  }
+export const metadata = {
+  title: 'Sync First Batch',
+  description: 'See how your sync turned out.',
+}
 
 // get FE journal name based on user's default journal
 const getFeJournalName = async (journalId, teamId) => {
   return await db.feJournal.findFirst({
     select: {
       journal: true,
-      id: true, 
+      id: true,
     },
     where: {
-        teamId: teamId,
-        id: parseInt(journalId),
+      teamId: teamId,
+      id: parseInt(journalId),
     },
   })
 }
 
-  // Get Batches from Latest Gifts for Samples
-
-
+// Get Batches from Latest Gifts for Samples
 
 export default async function ReveiwDataPage() {
   const user = await getCurrentUser()
-  if (!user) { 
+  if (!user) {
     redirect('/signUp')
   }
-  
-    const feAccountsData = getFeAccounts(user)
-    const projectsData = getVirtuousProjects(user)
-    const mappingData = getProjectAccountMappings(user)
-    const batchData = getVirtuousBatches(user)
-    const feEnvironmentData = getFeEnvironment(user)
-    const feGetJournalName = getFeJournalName(user.team.defaultJournal, user.id)
-    const [projects, feAccounts, mappings, batches, feEnvironment, journalName] = await Promise.all([projectsData, feAccountsData, mappingData, batchData, feEnvironmentData, feGetJournalName  ])
-    if (!feEnvironment) { 
-      redirect('/step2')
-    }
-    if (!journalName) { 
-      redirect('/step3')
-    }
 
-  return (<>
-    <div className="container grid w-screen ">
-    {batches && feAccounts && mappings && projects ? (
-           <FeFrame
-           batches={batches}
-           projects={projects}
-           feAccounts={feAccounts}
-           mappings={mappings}
-           defaultCreditAccount={user.team.defaultCreditAccount}
-           defaultDebitAccount={user.team.defaultDebitAccount}
-           defaultJournal={user.team.defaultJournal} 
-           feEnvironment={feEnvironment.environment_id}
-           journalName={journalName.journal}
-           className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
-         />
-        ) : `getting projects and accounts...`}
-      
-     
-    </div>
+  const feAccountsData = getFeAccountsFromBlackbaud(user)
+  const projectsData = getVirtuousProjects(user)
+  const mappingData = getProjectAccountMappings(user)
+  const batchData = getVirtuousBatches(user)
+  const feEnvironmentData = getFeEnvironment(user)
+  const feGetJournalName = getFeJournalName(user.team.defaultJournal, user.id)
+  const [projects, feAccounts, mappings, batches, feEnvironment, journalName] =
+    await Promise.all([
+      projectsData,
+      feAccountsData,
+      mappingData,
+      batchData,
+      feEnvironmentData,
+      feGetJournalName,
+    ])
+  if (!feEnvironment) {
+    redirect('/step2')
+  }
+  if (!journalName) {
+    redirect('/step3')
+  }
+
+  return (
+    <>
+      <div className="container grid w-screen ">
+        {batches && feAccounts && mappings && projects ? (
+          <FeFrame
+            batches={batches}
+            projects={projects}
+            feAccounts={feAccounts}
+            mappings={mappings}
+            defaultCreditAccount={user.team.defaultCreditAccount}
+            defaultDebitAccount={user.team.defaultDebitAccount}
+            defaultJournal={user.team.defaultJournal}
+            feEnvironment={feEnvironment.environment_id}
+            journalName={journalName.journal}
+            className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
+          />
+        ) : (
+          `getting projects and accounts...`
+        )}
+      </div>
     </>
   )
 }

--- a/app/(signupWizard)/step8/page.tsx
+++ b/app/(signupWizard)/step8/page.tsx
@@ -4,7 +4,6 @@ import { MappingCreateButton } from '@/components/dashboard/mapping-create-butto
 import { VirtuousSyncButton } from '@/components/dashboard/virtuous-sync-button'
 import { EmptyPlaceholder } from '@/components/empty-placeholder'
 import { Stepper } from '@/components/stepper'
-import { getFeAccounts } from '@/lib/feAccounts'
 import { getCurrentUser } from '@/lib/session'
 import { getVirtuousBatches } from '@/lib/virGifts'
 import { getVirtuousProjects } from '@/lib/virProjects'

--- a/app/api/mapping/route.ts
+++ b/app/api/mapping/route.ts
@@ -1,6 +1,6 @@
 import { authOptions } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { postPatchSchema } from '@/lib/validations/post'
+import { upsertFeAccountFromId } from '@/lib/feAccounts'
 import { getServerSession } from 'next-auth'
 import * as z from 'zod'
 
@@ -101,6 +101,12 @@ export async function POST(
     const body = mappingCreateSchema.parse(json)
     console.log(user)
     console.log(body)
+
+    // Cache FE Account so that we can always get to it during processing
+    if (body.feAccountID) {
+      upsertFeAccountFromId(body.feAccountID, user.team.id);
+    }
+    
     if (body?.virProjectIDs?.length == 0) {
       // update default account if nothing is set....this is defunct
       const userSettings = await db.team.update({

--- a/app/api/virSettings/route.ts
+++ b/app/api/virSettings/route.ts
@@ -43,7 +43,7 @@ export async function PATCH(
           virtuousAPI: body.apiKey,
         },
       })
-
+      
       const team = await db.team.update({
         where: {
           id: user.team.id,
@@ -64,3 +64,60 @@ export async function PATCH(
     }
   }
 
+
+  
+  export async function POST(
+    //this is used for testing an api key
+  req: Request,
+  ) {
+
+    const session = await getServerSession(authOptions)
+
+    if (!session?.user || !session?.user.email || !session?.user?.team.id) {
+      return new Response(null, { status: 403 })
+    }
+    const { user } = session
+ 
+  
+   
+    // Get the request body and validate it.
+    const json = await req.json()
+    console.log('getting json')
+    console.log(json)
+    const body = apiKeySchema.parse(json)
+    console.log(body) 
+
+    try { 
+      const params = {
+        method: 'GET',
+        headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${body.apiKey}`,
+        },
+  
+    } 
+      const res2 = await fetch(
+          'https://api.virtuoussoftware.com/api/Organization/Current',
+          params,
+          )
+      
+      
+    if (res2.status !== 200) {
+      console.log('Initial response failed - this could indicate a malformed request')
+      console.log(res2)
+        
+      const data = await res2.json()
+      console.log(data)
+      
+    return new Response(JSON.stringify(data));
+  }
+    const data = await res2.json()
+    console.log(data)
+
+    return new Response(JSON.stringify(data));
+    } catch (err) { 
+      console.log(err) 
+      console.log('Bigger issues than the refresh token')
+      return {json: ()=>null, status: 409}
+    }
+  }

--- a/components/dashboard/api-call-button.tsx
+++ b/components/dashboard/api-call-button.tsx
@@ -10,19 +10,27 @@ interface ButtonProps
   extends React.HTMLAttributes<HTMLButtonElement> {
   className?: string
   responseCallback?: Function
-
+  apiKey?: string
 }
 
-export function ApiCallButton({ className, responseCallback, ...props }: ButtonProps) {
+export function ApiCallButton({ className, apiKey, responseCallback, ...props }: ButtonProps) {
   const router = useRouter()
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
   const [organizationName, setOrganizationName] = React.useState<string>('')
   const [success, setSuccess] = React.useState<boolean>(false)
   async function onClick() {
+    console.log('onClick:' + apiKey)
     setIsLoading(true)
     setOrganizationName('Loading...')
-    const response = await fetch('/api/virOrg', {
-      method: 'GET',
+    const response = await fetch(`/api/virSettings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        apiKey: apiKey,
+       
+      }),
     })
 
     setIsLoading(false)

--- a/components/dashboard/universal-select.tsx
+++ b/components/dashboard/universal-select.tsx
@@ -1,14 +1,6 @@
 'use client'
 
-import { Fragment } from 'react'
 import { Icons } from '@/components/icons'
-import { toast } from '@/components/ui/use-toast'
-import { cn } from '@/lib/utils'
-import { useRouter, usePathname } from 'next/navigation'
-import { any } from 'prop-types'
-import * as React from 'react'
-import { set } from 'date-fns'
-import "@/styles/globals.css"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,52 +8,62 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-
+import { toast } from '@/components/ui/use-toast'
+import { cn } from '@/lib/utils'
+import '@/styles/globals.css'
+import { set } from 'date-fns'
+import { useRouter, usePathname } from 'next/navigation'
+import { any } from 'prop-types'
+import { Fragment } from 'react'
+import * as React from 'react'
 
 interface UniversalButtonProps {
-    title: String,
-    route: RequestInfo,
-    method: String,
-    fields: string[],
-    redirect: string,
-    selected: any,
-    subType?: string,
-  }
+  title: String
+  route: RequestInfo
+  method: String
+  fields: string[]
+  redirect: string
+  selected: any
+  subType?: string
+  initialData?: Array<any>
+}
 
 export function UniversalSelect({
-  title, 
-  route, 
+  title,
+  route,
   method,
   fields,
   selected,
   subType,
-  redirect, 
+  redirect,
+  initialData,
   ...props
 }: UniversalButtonProps) {
   const router = useRouter()
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
-  const [returnedData , setReturnedData] = React.useState(Array<{any}>)
-  const [selectValue, setSelectValue] = React.useState(selected)
+  const [returnedData, setReturnedData] = React.useState(initialData)
+  const [selectValue, setSelectValue] = React.useState(
+    selected ?? initialData?.[0][fields[0]]?.toString()
+  )
   const [selectTitle, setSelecTitle] = React.useState(selected)
   const [filterValue, setFilterValue] = React.useState('')
-  const [filteredObjects, setFilteredObjects] = React.useState(Array<{any}>)
+  const [filteredObjects, setFilteredObjects] = React.useState(initialData)
   console.log(selected)
-
 
   async function getInitialData() {
     console.log('getInitialData')
-    if (isLoading && route) {return}
+    if (isLoading && route) {
+      return
+    }
     setIsLoading(true)
     setReturnedData([])
     setFilterValue('')
     console.log(route)
-    
 
     const response = await fetch(route, {
       method: 'GET',
     })
 
-    
     console.log(response)
     if (!response?.ok) {
       if (response.status === 429) {
@@ -87,70 +89,100 @@ export function UniversalSelect({
     if (data?.length > 0) {
       setReturnedData(data)
       setFilteredObjects(data)
-   
-  
+
       if (selected === undefined || selected === null || selected === '') {
-      setSelectValue( (data[0][fields[0]])?.toString()  ) } 
+        setSelectValue(data[0][fields[0]]?.toString())
+      }
     }
     console.log(data[0][fields[0]])
     setIsLoading(false)
     // This forces a cache invalidation.
-  
   }
 
-  function selectLabel() { 
-    if (selectValue === undefined || selectValue === null || selectValue === '') {return <>Loading...</>}
-    if (returnedData.length === 0) {return <>Loading...</>}
+  function selectLabel() {
+    if (
+      selectValue === undefined ||
+      selectValue === null ||
+      selectValue === ''
+    ) {
+      return <>Loading...</>
+    }
+    if (returnedData.length === 0) {
+      return <>Loading...</>
+    }
     console.log('Selected Value')
     console.log(selectValue)
     const aLabel = returnedData.find((item, indexA) => {
       console.log(item[fields[0]].toString() === selectValue.toString())
-      return item[fields[0]].toString() === selectValue.toString() 
-    })  
+      return item[fields[0]].toString() === selectValue.toString()
+    })
     console.log('Selected Label')
     console.log(aLabel)
-    if (aLabel === undefined) {return <>Loading...</>}
-    let item=aLabel
-    return <>{fields?.map((field :any, index) =>  {if (index >0) { return <Fragment key={item[field] + index + '-key'} > {item[field]} </Fragment>} else  {return <Fragment key={item[field] + index + '-key'} ></Fragment>} }  )}</>
+    if (aLabel === undefined) {
+      return <>Loading...</>
+    }
+    let item = aLabel
+    return (
+      <>
+        {fields?.map((field: any, index) => {
+          if (index > 0) {
+            return (
+              <Fragment key={item[field] + index + '-key'}>
+                {' '}
+                {item[field]}{' '}
+              </Fragment>
+            )
+          } else {
+            return <Fragment key={item[field] + index + '-key'}></Fragment>
+          }
+        })}
+      </>
+    )
   }
-  
+
   function updateFilter() {
-          if (filterValue === '' || filterValue === null) {setFilteredObjects(returnedData)} else 
-          {
-        
-          setFilteredObjects(returnedData.filter((item)=>{
-            var text = ''
-          fields?.forEach((field :any, index) =>  {if (index > 0) { text = text + item[field]?.toString().toLowerCase()    } }  )
-          
+    if (filterValue === '' || filterValue === null) {
+      setFilteredObjects(returnedData)
+    } else {
+      setFilteredObjects(
+        returnedData.filter((item) => {
+          var text = ''
+          fields?.forEach((field: any, index) => {
+            if (index > 0) {
+              text = text + item[field]?.toString().toLowerCase()
+            }
+          })
+
           return text.includes(filterValue.toLowerCase())
-        
-        }))
-      }
-        
+        })
+      )
+    }
   }
 
   async function saveSelectedData() {
     console.log('getInitialData')
-    if (isLoading) {return}
+    if (isLoading) {
+      return
+    }
     setIsLoading(true)
 
     const bodyJson = JSON.stringify({
-        route: route,
-        selectValue: selectValue,
-        subType: subType,
-      })
-      console.log(bodyJson)
+      route: route,
+      selectValue: selectValue,
+      subType: subType,
+    })
+    console.log(bodyJson)
 
     const response = await fetch(route, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: bodyJson, 
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: bodyJson,
     })
 
-   
-   
+    setIsLoading(false)
+
     if (!response?.ok) {
       if (response.status === 429) {
         console.log(response)
@@ -162,91 +194,132 @@ export function UniversalSelect({
           variant: 'destructive',
         })
       }
-      setIsLoading(false)
       return toast({
         title: 'Something went wrong.',
         description: 'Your post was not created. Please try again.',
         variant: 'destructive',
       })
     }
-     router.push(redirect)
+
+    router.push(redirect)
   }
- 
-  if (!isLoading && returnedData?.length < 1) { 
-    
-        const user =  getInitialData()
+
+  if (!isLoading && (returnedData?.length ?? 0) < 1) {
+    getInitialData()
   }
+
   return (
-    <div className='w-100'>
-      
-    
-        <div className='w-100'>
+    <div className="w-100">
+      <div className="w-100">
+        <DropdownMenu>
+          {!isLoading ? (
+            <DropdownMenuTrigger className="text-md m-5 h-10 w-full overflow-hidden  rounded-full border border-accent-1 bg-accent-1 py-2 px-5 text-left text-dark focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500">
+              {selectLabel()}
+              <svg
+                className="float-right ml-2.5 mt-2 h-2.5 w-2.5"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 10 6"
+              >
+                <path
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="m1 1 4 4 4-4"
+                />
+              </svg>
+            </DropdownMenuTrigger>
+          ) : (
+            <div className="text-md mx-5 mt-4 mb-0 h-10 w-full overflow-hidden rounded-full  border border-accent-1 bg-accent-1 py-2 px-5  text-left text-dark focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500">
+              <div className="">
+                {selectLabel()}
+                <svg
+                  className="float-right ml-2.5 mt-2 h-2.5 w-2.5"
+                  aria-hidden="true"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 10 6"
+                >
+                  <path
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="m1 1 4 4 4-4"
+                  />
+                </svg>
+              </div>
+            </div>
+          )}
 
+          <DropdownMenuContent
+            align="start"
+            className="w-100 border-whiteSomke dropdown ml-5 border-none bg-whiteSmoke text-dark"
+          >
+            <input
+              type="text"
+              autoComplete="off"
+              className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2 pl-10 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+              value={filterValue}
+              onChange={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setFilterValue(e.target.value)
+                updateFilter()
+              }}
+              id="inputSearch"
+              placeholder="Search"
+            />
+            {filteredObjects?.map((item: any, index) => (
+              <DropdownMenuItem
+                className="w-100 border-whiteSomke border-none bg-whiteSmoke"
+                key={'option' + index}
+                data-value={item[fields[0]]}
+                onClick={(e) =>
+                  setSelectValue((e.target as HTMLElement).dataset.value)
+                }
+              >
+                {fields?.map((field: any, index) => {
+                  if (index > 0) {
+                    return (
+                      <Fragment key={item[field] + index + '-key'}>
+                        {' '}
+                        {item[field]}{' '}
+                      </Fragment>
+                    )
+                  } else {
+                    return (
+                      <Fragment key={item[field] + index + '-key'}></Fragment>
+                    )
+                  }
+                })}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
+        <br />
 
-
-<DropdownMenu>
-        {!isLoading ? <DropdownMenuTrigger className="text-md m-5 h-10 w-full overflow-hidden  rounded-full border border-accent-1 bg-accent-1 py-2 px-5 text-left text-dark focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500">
-        {selectLabel()}
-          <svg className="float-right ml-2.5 mt-2 h-2.5 w-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-    <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 4 4 4-4"/>
-  </svg>
-        </DropdownMenuTrigger> : <div className="text-md mx-5 mt-4 mb-0 h-10 w-full overflow-hidden rounded-full  border border-accent-1 bg-accent-1 py-2 px-5  text-left text-dark focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500">
-       <div className=''>{selectLabel()} 
-          <svg className="float-right ml-2.5 mt-2 h-2.5 w-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-    <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 4 4 4-4"/>
-  </svg></div> 
-        </div> }
-        
-
-        <DropdownMenuContent align='start' className='w-100 border-whiteSomke dropdown ml-5 border-none bg-whiteSmoke text-dark'>
-        <input type="text" autoComplete="off" className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2 pl-10 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500" value={filterValue} onChange={(e)=>{
-          e.preventDefault()
-          e.stopPropagation()
-          setFilterValue(e.target.value)
-          updateFilter()
-        }
-      
-        }
-        id="inputSearch" placeholder="Search" />
-  {filteredObjects?.map((item :any, index) => (
-    <DropdownMenuItem className='w-100 border-whiteSomke border-none bg-whiteSmoke' key={'option' + index} data-value={item[fields[0]]} onClick={(e)=>setSelectValue((e.target as HTMLElement).dataset.value)}>
-  {fields?.map((field :any, index) =>  {if (index >0) { return <Fragment key={item[field] + index + '-key'} > {item[field]} </Fragment>} else  {return <Fragment key={item[field] + index + '-key'} ></Fragment>} }  )}
-  </DropdownMenuItem>
-
-          ))}
-    
-    </DropdownMenuContent>
-      </DropdownMenu>
-
-
-
-<br/>
- 
-          
-
-
-            
-<button
-        onClick={saveSelectedData}
-        className={cn(
-          'font-large relative inline-flex h-9 items-center rounded-full border border-transparent bg-whiteSmoke  py-1  px-5 text-lg text-dark hover:bg-cyan focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2',
-          {
-            'cursor-not-allowed opacity-60': isLoading,
-          }
-        )}
-        disabled={isLoading}
-        {...props}
-      >
-        {isLoading ? (
-          <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
-        ) : (
-         <>{ title }</> 
-        )}
-       
-      </button>
-        </div>
-
+        <button
+          onClick={saveSelectedData}
+          className={cn(
+            'font-large relative inline-flex h-9 items-center rounded-full border border-transparent bg-whiteSmoke  py-1  px-5 text-lg text-dark hover:bg-cyan focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2',
+            {
+              'cursor-not-allowed opacity-60': isLoading,
+            }
+          )}
+          disabled={isLoading}
+          {...props}
+        >
+          {isLoading ? (
+            <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <>{title}</>
+          )}
+        </button>
+      </div>
     </div>
   )
 }

--- a/components/dashboard/virtuous-settings.tsx
+++ b/components/dashboard/virtuous-settings.tsx
@@ -42,6 +42,7 @@ export function VirtuousSettingsForm({
   const [isSaving, setIsSaving] = React.useState<boolean>(false)
   const [label, setLabel] = React.useState<string>('Save')
   const [updatedTeamName, setUpdatedTeamName] = React.useState(teamName || '')
+  const [formApiKey, setFormApiKey] = React.useState(apiKey )
   const responseCallback = (teamN)=> {
     console.log('New team Name')
     console.log(teamN) 
@@ -59,7 +60,7 @@ export function VirtuousSettingsForm({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        apiKey: data.apiKey,
+        apiKey: formApiKey,
         teamName: updatedTeamName || teamName,
       }),
     })
@@ -103,8 +104,9 @@ export function VirtuousSettingsForm({
             </label>
             <input
               id="apiKey"
+              onChange={(e)=>setFormApiKey( e.target.value || '')}
               className="mx-auto my-0 mb-2 block h-9 w-[350px] rounded-full border border-slate-300 py-2 px-3 text-sm text-slate-600 placeholder:text-slate-400 hover:border-slate-400 focus:border-neutral-300 focus:outline-none focus:ring-2 focus:ring-neutral-800 focus:ring-offset-1"
-              {...register('apiKey')}
+           
             />
             {errors?.apiKey && (
               <p className="text-red-600 px-1 text-xs">
@@ -130,7 +132,7 @@ export function VirtuousSettingsForm({
               <Icons.spinner className="display-inline float-lef mr-2 h-4 w-4 animate-spin" />
             ) : 
             <Icons.chevronRight className=" mr-2 h-4 w-4" /> }{label}
-          </button><p onClick={() =>setTested(false) } className="mt-4 cursor-default px-8 text-center text-sm text-muted-foreground">re-test api key</p></> : <><ApiCallButton responseCallback={responseCallback} />
+          </button><p onClick={() =>setTested(false) } className="mt-4 cursor-default px-8 text-center text-sm text-muted-foreground">re-test api key</p></> : <><ApiCallButton apiKey={formApiKey || ''} responseCallback={responseCallback} />
          </>
           }
         </CardFooter>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -57,7 +57,6 @@ export const authOptions: NextAuthOptions = {
   },
   providers: [
     EmailProvider({
-      
       from: process.env.SMTP_FROM,
       sendVerificationRequest: async ({ identifier, url, provider }) => {
         const user = await db.user.findUnique({

--- a/lib/feAccounts.ts
+++ b/lib/feAccounts.ts
@@ -1,107 +1,89 @@
 import { db } from '@/lib/db'
 import { reFetch } from '@/lib/reFetch'
 
+const mapFeAccount = (account, teamId) => ({
+  account_id: account.account_id,
+  account_number: account.account_number,
+  description: account.description,
+  prevent_data_entry: account.prevent_data_entry,
+  prevent_posting_data: account.prevent_posting,
+  class: account.class,
+  cashflow: account.cashflow,
+  working_capital: account.working_capital,
+  custom_fields: account.custom_fields,
+  default_transaction_codes: account.default_transaction_codes,
+  date_added: null,
+  added_by: account.added_by,
+  date_modified: new Date(account.date_modified),
+  modified_by: account.modified_by,
+  updatedAt: new Date(),
+  teamId: teamId,
+})
+
+export const getFeAccountsFromBlackbaud = async (user) => {
+  const res = await reFetch(
+    'https://api.sky.blackbaud.com/generalledger/v1/accounts',
+    'GET',
+    user.team.id
+  )
+  if (res.status !== 200) {
+    throw new Error('Unable to fetch accounts')
+  } else {
+    const data = await res.json()
+    //console.log('accounts', data)
+    return data.value.map((account) => mapFeAccount(account, user.team.id))
+  }
+}
 
 export const getFeAccounts = async (user) => {
-    let accounts =  await db.feAccount.findMany({
-      select: {
-        account_id: true,
-        account_number: true,       
-        description: true,          
-        class: true,
-        cashflow: true,
-        working_capital: true,
-        default_transaction_codes: true, 
-    
-      },
-      where: {
-        teamId: user.team.id,
-      },
-      orderBy: {
-        description: 'asc',
-      },
-    })
+  return await db.feAccount.findMany({
+    select: {
+      account_id: true,
+      account_number: true,
+      description: true,
+      class: true,
+      cashflow: true,
+      working_capital: true,
+      default_transaction_codes: true,
+    },
+    where: {
+      teamId: user.team.id,
+    },
+    orderBy: {
+      description: 'asc',
+    },
+  })
+}
 
-    if (accounts && accounts.length < 1) {
-      console.log('call blackbaud api')
-      const res2 = await reFetch('https://api.sky.blackbaud.com/generalledger/v1/accounts','GET', user.team.id)
-      if (res2.status !== 200) {
-        console.log('no accounts found')
-
-      } else { 
-        console.log('got accounts')
-        const data = await res2.json()
-        data?.value.forEach((account) => {
-          upsertFeAccount(account, user.team.id)
-        })
-      }
-     return accounts =  await db.feAccount.findMany({
-        select: {
-          account_id: true,
-          account_number: true,       
-          description: true,          
-          class: true,
-          cashflow: true,
-          working_capital: true,
-          default_transaction_codes: true, 
-        },
-        where: {
-          teamId: user.team.id,
-        },
-        orderBy: {
-          description: 'asc',
-        },
-      })
-    }
-    return accounts 
+export const upsertFeAccountFromId = async (accountId, teamId) => {
+  const res = await reFetch(
+    `https://api.sky.blackbaud.com/generalledger/v1/accounts/${accountId}`,
+    'GET',
+    teamId
+  )
+  if (res.status !== 200) {
+    throw new Error('Unable to get account')
+  } else {
+    const data = await res.json()
+    await upsertFeAccount(data, teamId);
   }
-
+}
 
 export async function upsertFeAccount(account, teamId) {
-  console.log('upsert account');
-    await db.feAccount.upsert({
-      where: {
-        account_id_teamId: { 
-          account_id: account.account_id,
-          teamId: teamId
-        },
-      },
-      update: {         
-        account_number: account.account_number,       
-        description: account.description,          
-        prevent_data_entry: account.prevent_data_entry,
-        prevent_posting_data: account.prevent_posting,
-        class: account.class,
-        cashflow: account.cashflow,
-        working_capital: account.working_capital,
-        custom_fields: account.custom_fields,
-        default_transaction_codes: account.default_transaction_codes,
-        date_added: null,          
-        added_by: account.added_by,
-        date_modified: new Date(account.date_modified),
-        modified_by: account.modified_by,
-        updatedAt: new Date(),       
-        teamId: teamId,                  
-      },
-      create: {
-        account_id: account.account_id,
-        account_number: account.account_number,       
-        description: account.description,          
-        prevent_data_entry: account.prevent_data_entry,
-        prevent_posting_data: account.prevent_posting,
-        class: account.class,
-        cashflow: account.cashflow,
-        working_capital: account.working_capital,
-        custom_fields: account.custom_fields,
-        default_transaction_codes: account.default_transaction_codes, 
-        date_added: null,          
-        added_by: account.added_by,
-        date_modified: new Date(account.date_modified),
-        modified_by: account.modified_by,
-        updatedAt: new Date(),       
-        teamId: teamId,              
-      },
-    })
+  const create = mapFeAccount(account, teamId)
+  const update = mapFeAccount(account, teamId)
+  delete update['account_id']
 
-    console.log('Done upsert account'); 
-  }
+  await db.feAccount.upsert({
+    where: {
+      account_id_teamId: {
+        account_id: account.account_id,
+        teamId: teamId,
+      },
+    },
+    update,
+    create,
+  })
+
+  console.log('Done upsert account')
+}


### PR DESCRIPTION
- Always get FE accounts straight from FE API when user needs them (onboarding, mapping, settings). This ensures that users always have an up-to-date list of accounts (in case they add more in FE), and that there is no issues trying to bulk-upsert accounts on initial load. This will make loading slightly slower for fetching them, but I consider that a fine trade-off considering we can ensure the data is up-to-date without having to frequently upsert.
- Cache FE accounts in planetscale on save: When a user chooses to use an account for a mapping or as an account default, it is then copied into our DB so that it is available for the sync jobs. This is only copying over one record at a time and so it will never be that slow of an operation. I only added the upsert logic on mapping and settings page, are there any others?

This still assumes that FE accounts don't change, we may need to consider periodically syncing our FE accounts with FE to make sure they are up to date.

Another upside of this change is that we only store the FE account data that we actually need, which is good for privacy and scalability.