### PR TITLE
Refactor virtuous project fetching, allow fetch more on mapping page

### DIFF
--- a/app/(private)/projectMapping/page.tsx
+++ b/app/(private)/projectMapping/page.tsx
@@ -2,6 +2,7 @@ import { MappingCreateButton } from '@/components/dashboard/mapping-create-butto
 import { db } from '@/lib/db'
 import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
 import { getCurrentUser } from '@/lib/session'
+import { dateFilterOptions } from '@/lib/utils'
 import { getVirtuousProjects } from '@/lib/virProjects'
 
 export const metadata = {
@@ -22,21 +23,28 @@ const getProjectAccountMappings = async (teamId) => {
   })
 }
 
-export default async function DataMapPage() {
+export default async function DataMapPage({ searchParams }) {
   const user = await getCurrentUser()
   if (!user) {
     return null
   }
+
+  const projectDays =
+    searchParams.projectDays && !Number.isNaN(searchParams.projectDays)
+      ? parseInt(searchParams.projectDays)
+      : dateFilterOptions[0]
+
+  const currentDateIndex = dateFilterOptions.indexOf(projectDays)
+  const nextProjectDays = dateFilterOptions[currentDateIndex + 1]
+
   const feAccountsData = getFeAccountsFromBlackbaud(user.team.id)
-  const projectsData = getVirtuousProjects(user.team.id)
+  const projectsData = getVirtuousProjects(user.team.id, projectDays)
   const mappingData = getProjectAccountMappings(user.team.id)
   const [projects, feAccounts, mappings] = await Promise.all([
     projectsData,
     feAccountsData,
     mappingData,
   ])
-  console.log('accounts length: ', feAccounts.length)
-  console.log('projects length: ', projects.length)
 
   return (
     <>
@@ -46,6 +54,8 @@ export default async function DataMapPage() {
             projects={projects}
             feAccounts={feAccounts}
             mappings={mappings}
+            nextProjectDays={nextProjectDays}
+            projectsDaysLoaded={projectDays}
             className="border-slate-200 bg-white text-brand-900 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2"
           />
         ) : (

--- a/app/(signupWizard)/step6/page.tsx
+++ b/app/(signupWizard)/step6/page.tsx
@@ -3,12 +3,12 @@ import { getFeAccountsFromBlackbaud } from '@/lib/feAccounts'
 import { getFeEnvironment } from '@/lib/feEnvironment'
 import { getFeJournalName } from '@/lib/feEnvironment'
 import { getCurrentUser } from '@/lib/session'
+import { dateFilterOptions } from '@/lib/utils'
 import {
-  dateFilterOptions,
+  getRelatedProjects,
   getVirtuousBatch,
   getVirtuousBatches,
 } from '@/lib/virGifts'
-import { getVirtuousProjects } from '@/lib/virProjects'
 import { getProjectAccountMappings } from '@/lib/virProjects'
 import { redirect } from 'next/navigation'
 
@@ -33,7 +33,6 @@ export default async function ReviewDataPage({ searchParams }) {
   const nextBatchDays = dateFilterOptions[currentDateIndex + 1]
 
   const feAccountsData = getFeAccountsFromBlackbaud(user.team.id)
-  const projectsData = getVirtuousProjects(user.team.id)
   const mappingData = getProjectAccountMappings(user.team.id)
   const batchData = getVirtuousBatches(user.team.id)
   const selectedBatchData = searchParams.batchId
@@ -45,7 +44,6 @@ export default async function ReviewDataPage({ searchParams }) {
     user.team.id
   )
   const [
-    projects,
     feAccounts,
     mappings,
     batches,
@@ -53,7 +51,6 @@ export default async function ReviewDataPage({ searchParams }) {
     journalName,
     selectedBatch,
   ] = await Promise.all([
-    projectsData,
     feAccountsData,
     mappingData,
     batchData,
@@ -61,6 +58,12 @@ export default async function ReviewDataPage({ searchParams }) {
     feGetJournalName,
     selectedBatchData,
   ])
+
+  // Only load needed projects for selected batch
+  let projects: any[] = []
+  if (selectedBatch) {
+    projects = await getRelatedProjects(selectedBatch)
+  }
 
   if (!feEnvironment) {
     redirect('/step2')

--- a/app/api/reJournalEntryBatches/route.ts
+++ b/app/api/reJournalEntryBatches/route.ts
@@ -1,24 +1,9 @@
 import { authOptions } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { upsertFeAccount } from '@/lib/feAccounts'
-import { getFeAccounts } from '@/lib/feAccounts'
 import { syncBatchGifts } from '@/lib/feGiftBatches'
 import { reFetch } from '@/lib/reFetch'
-import { absoluteUrl } from '@/lib/utils'
-import {
-  getBatches,
-  getVirtuousBatch,
-  insertGifts,
-  updateGiftBatch,
-} from '@/lib/virGifts'
-import { getVirtuousBatches } from '@/lib/virGifts'
-import { getVirtuousProjects } from '@/lib/virProjects'
-import { getProjectAccountMappings } from '@/lib/virProjects'
 import { getServerSession } from 'next-auth/next'
-import { any, number } from 'prop-types'
 import { z } from 'zod'
-
-const util = require('util')
 
 export type DesignationType = {
   projectId: string
@@ -29,21 +14,6 @@ const giftBatchSchema = z.object({
   batchId: z.string(),
   batchName: z.string(),
 })
-
-async function createSyncHistory(batchId, status, duration, teamId, userId) {
-  await db.syncHistory.create({
-    data: {
-      teamId: teamId,
-      giftBatchId: batchId,
-      syncType: 'manual',
-      syncMessage: status,
-      syncStatus: status,
-      syncDuration: duration,
-      syncDate: new Date(),
-      userId: userId,
-    },
-  })
-}
 
 export async function GET(req: Request) {
   try {

--- a/components/dashboard/batch-preview.tsx
+++ b/components/dashboard/batch-preview.tsx
@@ -110,19 +110,24 @@ export function BatchPreview({
 
   function lookupAccount(accountId) {
     const account = feAccounts.find((a) => a.account_id === accountId)
+    if (
+      accountId === parseInt(defaultCreditAccount) ||
+      accountId === parseInt(defaultDebitAccount)
+    ) {
+      return <span className="">{account?.description} (default)</span>
+    }
     return <span className="">{account?.description}</span>
   }
 
   function lookupMapping(projectId: number) {
     const project = projects.find((p) => p.id === projectId)
     const mapping = mappings.find((m) => m.virProjectId === projectId)
-    console.log(mapping)
     if (!mapping) {
       return (
         <span className="">
           {project?.name} <br />
           <Icons.arrowRight className="mr-2 inline h-4 w-4" />{' '}
-          {lookupAccount(parseInt(defaultCreditAccount))} (default)
+          {lookupAccount(parseInt(defaultCreditAccount))}
         </span>
       )
     }
@@ -301,7 +306,7 @@ export function BatchPreview({
           </div>
           <div className="mt-2">
             {batchDaysLoaded === 730 ? (
-              <p>Showing batches from the two years</p>
+              <p>Showing batches from the past two years</p>
             ) : batchDaysLoaded === 365 ? (
               <p>Showing batches from the past year</p>
             ) : (
@@ -437,7 +442,7 @@ export function BatchPreview({
                                 <>
                                   {/* do a credit if there are no designations */}
                                   <div className=" col-span-2  p-2 pl-3">
-                                    {lookupMapping(
+                                    {lookupAccount(
                                       parseInt(defaultCreditAccount)
                                     )}
                                   </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -17,3 +17,16 @@ export function formatDate(input: string | number): string {
 export function absoluteUrl(path: string) {
   return `${process.env.VERCEL_URL}${path}`
 }
+
+export const virDateOptions = {
+  30: '30 Days Ago',
+  60: '60 Days Ago',
+  90: '90 Days Ago',
+  180: '180 Days Ago',
+  270: '270 Days Ago',
+  365: 'One Year Ago',
+  730: 'Two Years Ago',
+}
+export const dateFilterOptions = Object.keys(virDateOptions).map((key) =>
+  parseInt(key)
+)

--- a/lib/virGifts.ts
+++ b/lib/virGifts.ts
@@ -1,4 +1,6 @@
+import { virDateOptions } from './utils'
 import { virApiFetch } from './virApiFetch'
+import { getVirtuousProjects } from './virProjects'
 import { db } from '@/lib/db'
 
 export const getBatches = async (teamId, dateFilter) => {
@@ -23,19 +25,6 @@ export const getBatches = async (teamId, dateFilter) => {
     },
   })
 }
-
-const virDateOptions = {
-  30: '30 Days Ago',
-  60: '60 Days Ago',
-  90: '90 Days Ago',
-  180: '180 Days Ago',
-  270: '270 Days Ago',
-  365: 'One Year Ago',
-  730: 'Two Years Ago',
-}
-export const dateFilterOptions = Object.keys(virDateOptions).map((key) =>
-  parseInt(key)
-)
 
 // Get batches from local DB and check Virtuous for any new ones
 export const getVirtuousBatches = async (teamId, dateFilter = 30) => {
@@ -102,6 +91,10 @@ export const getVirtuousBatches = async (teamId, dateFilter = 30) => {
       )
 
       batches = await getBatches(teamId, filterDate)
+
+      if (data.total < 1000) {
+        hasMoreData = false
+      }
     } else {
       console.log(`No more data from virtuous for past ${dateFilter} days`)
       hasMoreData = false
@@ -209,63 +202,71 @@ export async function updateGiftBatch(batchName, reBatchNo, teamId) {
 }
 
 export async function insertGifts(gifts, teamId, batch_name) {
-  return await db.gift.createMany(
-    {
-      data: gifts.map((gift) => ({
-        id: gift.id,
-        transactionSource: gift.transactionSource,
-        transactionId: gift.transactionId,
-        contactId: gift.contactId,
-        contactName: gift.contactName,
-        contactUrl: gift.contactUrl,
-        giftType: gift.giftType,
-        giftTypeFormatted: gift.giftTypeFormatted,
-        giftDate: new Date(gift.giftDate),
-        giftDateFormatted: gift.giftDateFormatted,
-        amount: gift.amount,
-        amountFormatted: gift.amountFormatted,
-        currencyCode: gift.currencyCode,
-        exchangeRate: gift.exchangeRate,
-        baseCurrencyCode: gift.baseCurrencyCode,
-        batch: gift.batch,
-        createDateTimeUtc: new Date(gift.createDateTimeUtc),
-        createdByUser: gift.createdByUser,
-        modifiedDateTimeUtc: new Date(gift.modifiedDateTimeUtc),
-        modifiedByUser: gift.modifiedByUser,
-        segmentId: gift.segmentId,
-        segment: gift.segment,
-        segmentCode: gift.segmentCode,
-        segmentUrl: gift.segmentUrl,
-        mediaOutletId: gift.mediaOutletId,
-        mediaOutlet: gift.mediaOutlet,
-        grantId: gift.grantId,
-        grant: gift.grant,
-        grantUrl: gift.grantUrl,
-        notes: gift.notes,
-        tribute: gift.tribute,
-        tributeId: gift.tributeId,
-        tributeType: gift.tributeType,
-        acknowledgeIndividualId: gift.acknowledgeIndividualId,
-        receiptDate: new Date(gift.receiptDate),
-        receiptDateFormatted: gift.receiptDateFormatted,
-        contactPassthroughId: gift.contactPassthroughId,
-        contactPassthroughUrl: gift.contactPassthroughUrl,
-        contactIndividualId: gift.contactIndividual,
-        cashAccountingCode: gift.cashAccountingCode,
-        giftAskId: gift.giftAskId,
-        contactMembershipId: gift.contactMembershipId,
-        giftUrl: gift.giftUrl,
-        isTaxDeductible: gift.isTaxDeductible,
-        giftDesignations: gift.giftDesignations,
-        giftPremiums: gift.giftPremiums,
-        recurringGiftPayments: gift.recurringGiftPayments,
-        pledgePayments: gift.pledgePayments,
-        customFields: gift.customFields,
-        batch_name: gift.batch || 'none',
-        synced: true,
-        teamId,
-      })),
-      skipDuplicates: true
-    }
-  )
+  return await db.gift.createMany({
+    data: gifts.map((gift) => ({
+      id: gift.id,
+      transactionSource: gift.transactionSource,
+      transactionId: gift.transactionId,
+      contactId: gift.contactId,
+      contactName: gift.contactName,
+      contactUrl: gift.contactUrl,
+      giftType: gift.giftType,
+      giftTypeFormatted: gift.giftTypeFormatted,
+      giftDate: new Date(gift.giftDate),
+      giftDateFormatted: gift.giftDateFormatted,
+      amount: gift.amount,
+      amountFormatted: gift.amountFormatted,
+      currencyCode: gift.currencyCode,
+      exchangeRate: gift.exchangeRate,
+      baseCurrencyCode: gift.baseCurrencyCode,
+      batch: gift.batch,
+      createDateTimeUtc: new Date(gift.createDateTimeUtc),
+      createdByUser: gift.createdByUser,
+      modifiedDateTimeUtc: new Date(gift.modifiedDateTimeUtc),
+      modifiedByUser: gift.modifiedByUser,
+      segmentId: gift.segmentId,
+      segment: gift.segment,
+      segmentCode: gift.segmentCode,
+      segmentUrl: gift.segmentUrl,
+      mediaOutletId: gift.mediaOutletId,
+      mediaOutlet: gift.mediaOutlet,
+      grantId: gift.grantId,
+      grant: gift.grant,
+      grantUrl: gift.grantUrl,
+      notes: gift.notes,
+      tribute: gift.tribute,
+      tributeId: gift.tributeId,
+      tributeType: gift.tributeType,
+      acknowledgeIndividualId: gift.acknowledgeIndividualId,
+      receiptDate: new Date(gift.receiptDate),
+      receiptDateFormatted: gift.receiptDateFormatted,
+      contactPassthroughId: gift.contactPassthroughId,
+      contactPassthroughUrl: gift.contactPassthroughUrl,
+      contactIndividualId: gift.contactIndividual,
+      cashAccountingCode: gift.cashAccountingCode,
+      giftAskId: gift.giftAskId,
+      contactMembershipId: gift.contactMembershipId,
+      giftUrl: gift.giftUrl,
+      isTaxDeductible: gift.isTaxDeductible,
+      giftDesignations: gift.giftDesignations,
+      giftPremiums: gift.giftPremiums,
+      recurringGiftPayments: gift.recurringGiftPayments,
+      pledgePayments: gift.pledgePayments,
+      customFields: gift.customFields,
+      batch_name: gift.batch || 'none',
+      synced: true,
+      teamId,
+    })),
+    skipDuplicates: true,
+  })
+}
+
+export function getRelatedProjects(
+  batch: Awaited<ReturnType<typeof getVirtuousBatch>>
+) {
+  const projectIds = new Set<string>()
+  batch.gifts
+    .flatMap((gift) => gift.giftDesignations)
+    .forEach(({ projectId }) => projectIds.add(projectId))
+  return getVirtuousProjects(batch.teamId, Array.from(projectIds))
 }


### PR DESCRIPTION
- On batch management pages, only fetch the projects needed for the selected batch, instead of all projects from the past 30 days
- On the project mapping page, implement a "load more projects" feature similar to the "load more batches" feature on the batch management page. Allow loading up to two years of projects
- Bypass extra gift fetch call when getting gift batches by exiting sooner when we know there won't be any more data
- Clean up misc unused imports, functions, and log statements