### PR TITLE
Fix projectMapping virtuous project name, tweak styling

### DIFF
--- a/app/(private)/projectMapping/page.tsx
+++ b/app/(private)/projectMapping/page.tsx
@@ -14,6 +14,7 @@ const getProjectAccountMappings = async (teamId) => {
   return await db.projectAccountMapping.findMany({
     select: {
       id: true,
+      virProjectName: true,
       virProjectId: true,
       feAccountId: true,
     },

--- a/app/(signupWizard)/step5/page.tsx
+++ b/app/(signupWizard)/step5/page.tsx
@@ -10,29 +10,6 @@ export const metadata = {
   description: 'Select which projects should map to which accounts.',
 }
 
-const getFeProjects = async (teamId) => {
-  return await db.feProject.findMany({
-    select: {
-      id: true,
-      project_id: true,
-      ui_project_id: true,
-      description: true,
-      location: true,
-      division: true,
-      department: true,
-      status: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-    where: {
-      teamId: teamId,
-    },
-    orderBy: {
-      description: 'asc',
-    },
-  })
-}
-
 const getProjectAccountMappings = async (teamId) => {
   return await db.projectAccountMapping.findMany({
     select: {

--- a/components/dashboard/mapping-create-button.tsx
+++ b/components/dashboard/mapping-create-button.tsx
@@ -656,14 +656,17 @@ export function MappingCreateButton({
             {mappings.map((mapping) => (
               <div className="p-1" key={mapping.id}>
                 <div className="flex items-center">
-                  {' '}
                   <Icons.trash
                     className="mr-2 h-4 w-4 text-red-500"
                     onClick={() => onDeleteMapping(mapping.id)}
-                  />{' '}
-                  {mapping.virProjectName}{' '}
-                  <Icons.arrowRight className="mr-2 h-4 w-4" />{' '}
-                  {lookupAccount(mapping.feAccountId)}
+                  />
+                  <span className="flex-1 text-right">
+                    {mapping.virProjectName}
+                  </span>
+                  <Icons.arrowRight className="mx-2 h-4 w-4" />{' '}
+                  <span className="flex-1">
+                    {lookupAccount(mapping.feAccountId)}
+                  </span>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
Before:
<img width="422" alt="Screenshot 2023-11-08 at 1 42 15 PM" src="https://github.com/Rooted-Software/taxonomy-sanity/assets/10255587/5f9d68cb-0db3-4d23-b2a9-d53d5cddacf8">

With just name fix:
<img width="394" alt="Screenshot 2023-11-08 at 1 42 46 PM" src="https://github.com/Rooted-Software/taxonomy-sanity/assets/10255587/a97a9ee6-d542-4ccd-8acd-e0c6927cf55a">

With styling change:
<img width="425" alt="Screenshot 2023-11-08 at 1 41 35 PM" src="https://github.com/Rooted-Software/taxonomy-sanity/assets/10255587/cbdbbc74-4993-4a04-b5ff-8fd367ea9494">

Also removed unused code in step5